### PR TITLE
Used replaces for finding versions and missing dependencies

### DIFF
--- a/src/Validator/Rule/IncompatibleVersionRule.php
+++ b/src/Validator/Rule/IncompatibleVersionRule.php
@@ -8,6 +8,7 @@ use Composer\Semver\VersionParser;
 use Nusje2000\ComposerMonolith\Validator\RuleInterface;
 use Nusje2000\ComposerMonolith\Validator\Violation\IncompatibleVersionConstraintViolation;
 use Nusje2000\ComposerMonolith\Validator\ViolationCollection;
+use Nusje2000\DependencyGraph\Dependency\DependencyInterface;
 use Nusje2000\DependencyGraph\DependencyGraph;
 
 final class IncompatibleVersionRule implements RuleInterface
@@ -24,26 +25,54 @@ final class IncompatibleVersionRule implements RuleInterface
 
     public function execute(DependencyGraph $graph): ViolationCollection
     {
-        $rootPackage = $graph->getRootPackage();
         $subPackages = $graph->getSubPackages();
         $violations = new ViolationCollection();
 
         foreach ($subPackages as $subPackage) {
             foreach ($subPackage->getDependencies() as $dependency) {
-                if (!$rootPackage->hasDependency($dependency->getName())) {
+                $rootVersionConstraint = $this->getRootVersionConstraint($graph, $dependency);
+                if (null === $rootVersionConstraint) {
                     continue;
                 }
 
-                $rootDependency = $rootPackage->getDependency($dependency->getName());
-                if (!$this->isCompatible($rootDependency->getVersionConstraint(), $dependency->getVersionConstraint())) {
+                if (!$this->isCompatible($rootVersionConstraint, $dependency->getVersionConstraint())) {
                     $violations->append(
-                        new IncompatibleVersionConstraintViolation($subPackage, $dependency, $rootDependency->getVersionConstraint())
+                        new IncompatibleVersionConstraintViolation($subPackage, $dependency, $rootVersionConstraint)
                     );
                 }
             }
         }
 
         return $violations;
+    }
+
+    private function getRootVersionConstraint(DependencyGraph $graph, DependencyInterface $dependency): ?string
+    {
+        $rootPackage = $graph->getRootPackage();
+        if ($rootPackage->hasDependency($dependency->getName())) {
+            return $rootPackage->getDependencies()->getDependencyByName($dependency->getName())->getVersionConstraint();
+        }
+
+        foreach ($rootPackage->getDependencies() as $rootDependency) {
+            if (!$graph->hasPackage($rootDependency->getName())) {
+                continue;
+            }
+
+            $dependencyPackage = $graph->getPackage($rootDependency->getName());
+            if ($dependencyPackage->getReplaces()->hasReplaceByName($dependency->getName())) {
+                $replacedVersion = $dependencyPackage->getReplaces()->getReplaceByName(
+                    $dependency->getName()
+                )->getVersion();
+
+                if ('self.version' === $replacedVersion) {
+                    return $rootDependency->getVersionConstraint();
+                }
+
+                return $replacedVersion;
+            }
+        }
+
+        return null;
     }
 
     private function isCompatible(string $rootVersionConstraint, string $subPackageVersionConstraint): bool

--- a/src/Validator/Rule/MissingDependencyRule.php
+++ b/src/Validator/Rule/MissingDependencyRule.php
@@ -7,6 +7,8 @@ namespace Nusje2000\ComposerMonolith\Validator\Rule;
 use Nusje2000\ComposerMonolith\Validator\RuleInterface;
 use Nusje2000\ComposerMonolith\Validator\Violation\MissingDependencyViolation;
 use Nusje2000\ComposerMonolith\Validator\ViolationCollection;
+use Nusje2000\DependencyGraph\Dependency\DependencyInterface;
+use Nusje2000\DependencyGraph\Dependency\DependencyTypeEnum;
 use Nusje2000\DependencyGraph\DependencyGraph;
 
 final class MissingDependencyRule implements RuleInterface
@@ -24,12 +26,35 @@ final class MissingDependencyRule implements RuleInterface
                     continue;
                 }
 
-                if (!$rootPackage->hasDependency($dependency->getName())) {
+                if (
+                    !$rootPackage->hasDependency($dependency->getName())
+                    && !$this->isReplacedDependency($graph, $dependency)
+                ) {
                     $violations->append(new MissingDependencyViolation($subPackage, $dependency));
                 }
             }
         }
 
         return $violations;
+    }
+
+    private function isReplacedDependency(DependencyGraph $graph, DependencyInterface $dependency): bool
+    {
+        $rootPackage = $graph->getRootPackage();
+        foreach ($rootPackage->getDependencies() as $rootDependency) {
+            if (
+                !$rootDependency->getType()->equals(new DependencyTypeEnum(DependencyTypeEnum::PACKAGE))
+                || !$graph->hasPackage($rootDependency->getName())
+            ) {
+                continue;
+            }
+
+            $dependencyPackage = $graph->getPackage($rootDependency->getName());
+            if ($dependencyPackage->getReplaces()->hasReplaceByName($dependency->getName())) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/Validator/Rule/IncompatibleVersionRuleTest.php
+++ b/tests/Validator/Rule/IncompatibleVersionRuleTest.php
@@ -11,6 +11,8 @@ use Nusje2000\DependencyGraph\Dependency\DependencyTypeEnum;
 use Nusje2000\DependencyGraph\DependencyGraph;
 use Nusje2000\DependencyGraph\Package\Package;
 use Nusje2000\DependencyGraph\Package\PackageCollection;
+use Nusje2000\DependencyGraph\Replace\Replace;
+use Nusje2000\DependencyGraph\Replace\ReplaceCollection;
 use PHPStan\Testing\TestCase;
 
 final class IncompatibleVersionRuleTest extends TestCase
@@ -20,6 +22,7 @@ final class IncompatibleVersionRuleTest extends TestCase
         $graph = new DependencyGraph('/path/to/root', new PackageCollection([
             new Package('foo/framework', '/path/to/root', false, new DependencyCollection([
                 new Dependency('bar/bar-package', '~1.0', false, new DependencyTypeEnum(DependencyTypeEnum::PACKAGE)),
+                new Dependency('baz/baz-package', '~1.0', false, new DependencyTypeEnum(DependencyTypeEnum::PACKAGE)),
             ])),
             new Package('foo/package-1', '/path/to/root/package-1', false, new DependencyCollection([
                 new Dependency('bar/bar-package', '1.1', false, new DependencyTypeEnum(DependencyTypeEnum::PACKAGE)),
@@ -33,8 +36,26 @@ final class IncompatibleVersionRuleTest extends TestCase
             new Package('foo/package-4', '/path/to/root/package-4', false, new DependencyCollection([
                 new Dependency('bar/bar-package', '^2.0', false, new DependencyTypeEnum(DependencyTypeEnum::PACKAGE)),
             ])),
-            new Package('foo/package-4', '/path/to/root/package-4', false, new DependencyCollection([
+            new Package('foo/package-5', '/path/to/root/package-5', false, new DependencyCollection([
                 new Dependency('foo/foo-package', '^2.0', false, new DependencyTypeEnum(DependencyTypeEnum::PACKAGE)),
+            ])),
+            new Package('foo/package-6', '/path/to/root/package-6', false, new DependencyCollection([
+                new Dependency('beep/beep-package', '^1.1', false, new DependencyTypeEnum(DependencyTypeEnum::PACKAGE)),
+            ])),
+            new Package('foo/package-7', '/path/to/root/package-7', false, new DependencyCollection([
+                new Dependency('beep/beep-package', '^2.0', false, new DependencyTypeEnum(DependencyTypeEnum::PACKAGE)),
+            ])),
+            new Package('foo/package-8', '/path/to/root/package-8', false, new DependencyCollection([
+                new Dependency('boop/boop-package', '^1.1', false, new DependencyTypeEnum(DependencyTypeEnum::PACKAGE)),
+            ])),
+            new Package('foo/package-9', '/path/to/root/package-9', false, new DependencyCollection([
+                new Dependency('boop/boop-package', '^2.0', false, new DependencyTypeEnum(DependencyTypeEnum::PACKAGE)),
+            ])),
+            new Package('bar/bar-package', '/path/to/vendor/bar', true),
+            new Package('foo/foo-package', '/path/to/vendor/foo', true),
+            new Package('baz/baz-package', '/path/to/vendor/baz', true, null, null, new ReplaceCollection([
+                new Replace('beep/beep-package', 'self.version'),
+                new Replace('boop/boop-package', '^1.0'),
             ])),
         ]));
 
@@ -44,11 +65,15 @@ final class IncompatibleVersionRuleTest extends TestCase
         self::assertSame([
             'Dependency on "bar/bar-package" in package "foo/package-3" requires version that matches "2.0". (installed: ~1.0)',
             'Dependency on "bar/bar-package" in package "foo/package-4" requires version that matches "^2.0". (installed: ~1.0)',
+            'Dependency on "beep/beep-package" in package "foo/package-7" requires version that matches "^2.0". (installed: ~1.0)',
+            'Dependency on "boop/boop-package" in package "foo/package-9" requires version that matches "^2.0". (installed: ^1.0)',
         ], $violations->getMessages()->toArray());
 
         self::assertSame([
             'Dependency on <dependency>"bar/bar-package"</dependency> in package <package>"foo/package-3"</package> requires version that matches <version>2.0</version>. (installed: <version>~1.0</version>)',
             'Dependency on <dependency>"bar/bar-package"</dependency> in package <package>"foo/package-4"</package> requires version that matches <version>^2.0</version>. (installed: <version>~1.0</version>)',
+            'Dependency on <dependency>"beep/beep-package"</dependency> in package <package>"foo/package-7"</package> requires version that matches <version>^2.0</version>. (installed: <version>~1.0</version>)',
+            'Dependency on <dependency>"boop/boop-package"</dependency> in package <package>"foo/package-9"</package> requires version that matches <version>^2.0</version>. (installed: <version>^1.0</version>)',
         ], $violations->getFormattedMessages()->toArray());
     }
 }

--- a/tests/Validator/Rule/MissingDependencyRuleTest.php
+++ b/tests/Validator/Rule/MissingDependencyRuleTest.php
@@ -11,6 +11,8 @@ use Nusje2000\DependencyGraph\Dependency\DependencyTypeEnum;
 use Nusje2000\DependencyGraph\DependencyGraph;
 use Nusje2000\DependencyGraph\Package\Package;
 use Nusje2000\DependencyGraph\Package\PackageCollection;
+use Nusje2000\DependencyGraph\Replace\Replace;
+use Nusje2000\DependencyGraph\Replace\ReplaceCollection;
 use PHPStan\Testing\TestCase;
 
 final class MissingDependencyRuleTest extends TestCase
@@ -20,6 +22,7 @@ final class MissingDependencyRuleTest extends TestCase
         $graph = new DependencyGraph('/path/to/root', new PackageCollection([
             new Package('foo/framework', '/path/to/root', false, new DependencyCollection([
                 new Dependency('foo/foo-package', '1.0', false, new DependencyTypeEnum(DependencyTypeEnum::PACKAGE)),
+                new Dependency('baz/baz-package', '1.0', false, new DependencyTypeEnum(DependencyTypeEnum::PACKAGE)),
             ])),
             new Package('foo/package-1', '/path/to/root/package-1', false, new DependencyCollection([
                 new Dependency('foo/package-2', '~1.0', true, new DependencyTypeEnum(DependencyTypeEnum::PACKAGE)),
@@ -31,6 +34,14 @@ final class MissingDependencyRuleTest extends TestCase
             new Package('foo/package-3', '/path/to/root/package-3', false, new DependencyCollection([
                 new Dependency('foo/foo-package', '1.0', false, new DependencyTypeEnum(DependencyTypeEnum::PACKAGE)),
                 new Dependency('bar/bar-package', '1.0', false, new DependencyTypeEnum(DependencyTypeEnum::PACKAGE)),
+            ])),
+            new Package('foo/package-4', '/path/to/root/package-3', false, new DependencyCollection([
+                new Dependency('beep/beep-package', '1.0', false, new DependencyTypeEnum(DependencyTypeEnum::PACKAGE)),
+                new Dependency('boop/boop-package', '1.0', false, new DependencyTypeEnum(DependencyTypeEnum::PACKAGE)),
+            ])),
+            new Package('baz/baz-package', '/path/to/vendor/baz', true, null, null, new ReplaceCollection([
+                new Replace('beep/beep-package', 'self.version'),
+                new Replace('boop/boop-package', '1.0'),
             ])),
         ]));
 


### PR DESCRIPTION
Used replaces for finding versions and missing dependencies when they are not required by the root composer.json directly.

Fixes #6